### PR TITLE
[tkt-58] Unifies folder and file creation mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 !*.default.ini
 !conf/i18n/*.ini
 sgallery.properties
+!/conf/sgallery.properties
 !/tests/**/sgallery.properties
 
 

--- a/conf/sgallery.properties
+++ b/conf/sgallery.properties
@@ -17,20 +17,27 @@ language = en
 
 
 
-;; 
+;;
+; Public folder
+public.folderMode = 0750
+public.fileMode = 0640
+
+
+
+;;
 ; THUMBNAILS & COVERS
 
 ; Defines which image module should be used for image processing.
 image.module = 'gd'
 
-; Quality for generated thumbnails. 100 no compression, 0 full 
+; Quality for generated thumbnails. 100 no compression, 0 full
 ; compression.
 thumbnails.quality = 75
 
 ; Size for generated thumbnails
 thumbnails.size = 230
 
-; Max width or height of your source Image. Depending on your PHP 
+; Max width or height of your source Image. Depending on your PHP
 ; memory limit settings. For 128M keep it around 4000.
 thumbnails.sourceMaxSize = 4000
 

--- a/src/Hoborg/SGallery/Application.php
+++ b/src/Hoborg/SGallery/Application.php
@@ -26,6 +26,15 @@ class Application extends ConsoleApplication {
 			'Specify config file.',
 			'sgallery.properties'
 		));
+
+		$this->add(new Command\InstallCommand());
+		$this->add(new Command\InstallAssetsCommand());
+
+		$this->add(new Command\UpdateCommand());
+		$this->add(new Command\RefreshThumbnailsCommand());
+		$this->add(new Command\RefreshCoversCommand());
+		$this->add(new Command\RefreshHtmlCommand());
+		$this->add(new Command\RefreshJsonCommand());
 	}
 
 	public function doRun(InputInterface $input, OutputInterface $output) {
@@ -33,6 +42,15 @@ class Application extends ConsoleApplication {
 		$options = $input->getOptions();
 
 		$this->setConfigurationOverride($options['config']);
+		$this->setCatchExceptions(true);
+
+		$imageFinder = new Image\Finder($this);
+		$image = Image\Image::createFromConfig($this->getConfiguration());
+
+		$this->get('install:assets')->inject($imageFinder);
+		$this->get('refresh:thumbnails')->inject($image, $imageFinder);
+		$this->get('refresh:covers')->inject($image, $imageFinder);
+		$this->get('refresh:json')->inject($imageFinder);
 
 		return parent::doRun($input, $output);
 	}
@@ -108,20 +126,4 @@ class Application extends ConsoleApplication {
 		$output->writeln($error);
 		exit(1);
 	}
-
-	protected function getDefaultCommands() {
-		$commands = parent::getDefaultCommands();
-
-		$commands[] = new Command\InstallCommand();
-		$commands[] = new Command\InstallAssetsCommand();
-
-		$commands[] = new Command\UpdateCommand();
-		$commands[] = new Command\RefreshThumbnailsCommand();
-		$commands[] = new Command\RefreshCoversCommand();
-		$commands[] = new Command\RefreshHtmlCommand();
-		$commands[] = new Command\RefreshJsonCommand();
-
-		return $commands;
-	}
-
 }

--- a/src/Hoborg/SGallery/Command/InstallAssetsCommand.php
+++ b/src/Hoborg/SGallery/Command/InstallAssetsCommand.php
@@ -1,6 +1,7 @@
 <?php
 namespace Hoborg\SGallery\Command;
 
+use Hoborg\SGallery\Image\Finder;
 use Symfony\Component\Console\Command\Command,
 	Symfony\Component\Console\Input\InputArgument,
 	Symfony\Component\Console\Input\InputInterface,
@@ -17,6 +18,10 @@ class InstallAssetsCommand extends Command {
 	protected function configure() {
 		$this->setName('install:assets')
 			->setDescription('Install JS and CSS assets.');
+	}
+
+	public function inject(Finder $imageFinder) {
+		$this->imageFinder = $imageFinder;
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
@@ -38,13 +43,17 @@ class InstallAssetsCommand extends Command {
 	protected function copyJs(array $config) {
 		$sourceDir = $this->getApplication()->getAppRoot() . '/dist/static/scripts/hoborglabs';
 		$targetDir = $config['target'] . '/static/scripts/hoborglabs';
+
 		return copy($sourceDir . '/app.js', $targetDir . '/app.js');
 	}
 
 	protected function copyCss(array $config) {
 		$sourceDir = $this->getApplication()->getAppRoot() . '/dist/static/styles/hoborglabs/';
 		$targetDir = $config['target'] . '/static/styles/hoborglabs/';
+
+		// FIXME: this should be a recursive copy of folder.
 		copy($sourceDir . 'gfx', $targetDir);
+
 		return copy($sourceDir . 'css/main.css', $targetDir . 'css/main.css');
 	}
 
@@ -71,11 +80,7 @@ class InstallAssetsCommand extends Command {
 		}
 
 		foreach ($this->assetsFolders as $assetfolder) {
-			if (!is_readable($config['target'] . $assetfolder)) {
-				if (!mkdir($config['target'] . $assetfolder, 0770, true)) {
-					throw new \Exception('Can not create ' . $config['target'] . $assetfolder, 1);
-				}
-			}
+			$this->imageFinder->ensureFodlerExists($config['target'] . $assetfolder);
 		}
 	}
 

--- a/src/Hoborg/SGallery/Command/RefreshJsonCommand.php
+++ b/src/Hoborg/SGallery/Command/RefreshJsonCommand.php
@@ -21,6 +21,10 @@ class RefreshJsonCommand extends Command {
 			->setDescription('Refresh gallery HTML.');
 	}
 
+	public function inject(Finder $imageFinder) {
+		$this->imageFinder = $imageFinder;
+	}
+
 	protected function execute(InputInterface $input, OutputInterface $output) {
 
 		$output->writeln("\n<info>Refresh JSON Files.</info>");
@@ -28,7 +32,6 @@ class RefreshJsonCommand extends Command {
 
 		// check source and target folders
 		$this->check($config);
-		$this->imageFinder = new Finder($this->getApplication());
 		$this->m = new \Mustache_Engine(array('charset' => 'UTF-8'));
 
 		$this->progressOut = new \Hoborg\SGallery\Output\Progress($output, $this->countFolders($config['source']));
@@ -109,11 +112,8 @@ class RefreshJsonCommand extends Command {
 		if (!is_writable($config['target'])) {
 			throw new \Exception('Target folder is not writable', 1);
 		}
-		if (!is_readable($config['target'] . '/static/json')) {
-			if (!mkdir($config['target'] . '/static/json', 0770, true)) {
-				throw new \Exception('Can not create ' . $config['target'] . '/static/json', 1);
-			}
-		}
+
+		$this->imageFinder->ensureFodlerExists($config['target'] . '/static/json');
 	}
 
 	protected function countFolders($folder) {

--- a/src/Hoborg/SGallery/Image/Finder.php
+++ b/src/Hoborg/SGallery/Image/Finder.php
@@ -26,6 +26,32 @@ class Finder {
 		return "/static/thumbnails/{$thumb}{$suffix}";
 	}
 
+	public function ensureFodlerExists($folder) {
+		$config = $this->app->getConfiguration();
+		$mode = isset($config['public.folderMode']) ? $config['public.folderMode'] : '0750';
+		$oldUmask = umask(0);
+
+		if (!is_readable($folder)) {
+			if (!mkdir($folder, intval($mode, 8), true)) {
+				umask($oldUmask);
+				throw new \Exception('Can not create ' . $folder, 1);
+			}
+		}
+
+		umask($oldUmask);
+	}
+
+	public function ensureFileMode($file) {
+		$config = $this->app->getConfiguration();
+		$mode = isset($config['public.fileMode']) ? $config['public.fileMode'] : '0440';
+
+		$oldUmask = umask(0);
+		chmod($file, intval($mode, 8));
+		umask($oldUmask);
+
+		return true;
+	}
+
 	protected function getThumb($file) {
 		$md5 = md5($file);
 		$folder = substr($md5, 0, 3);

--- a/src/Hoborg/SGallery/Image/GD.php
+++ b/src/Hoborg/SGallery/Image/GD.php
@@ -63,7 +63,6 @@ class GD implements ImageInterface {
 		$y = ($l == $height) ? 0 : round(($height - $l) / 2);
 
 		$thumb = imagecreatetruecolor($size, $size);
-		$this->ensureFodlerExists(dirname($dstFile));
 
 		// Resize
 		imagecopyresampled($thumb, $source, 0, 0, $x, $y, $size, $size, $l, $l);
@@ -90,8 +89,6 @@ class GD implements ImageInterface {
 	}
 
 	public function assembleCover(array $coverImages, $coverFileName, $size) {
-		$this->ensureFodlerExists(dirname($coverFileName));
-
 		if (count($coverImages) == 1) {
 			return copy($coverImages[0], $coverFileName);
 		}
@@ -137,13 +134,5 @@ class GD implements ImageInterface {
 		}
 
 		return null;
-	}
-
-	protected function ensureFodlerExists($folder) {
-		if (!is_readable($folder)) {
-			if (!mkdir($folder, 0770, true)) {
-				throw new \Exception('Can not create ' . $folder, 1);
-			}
-		}
 	}
 }


### PR DESCRIPTION
Image/Finder is now used to create missing folders and ensure that
correct access rights are set on files.
This commit also changes the way commands objects get their
dependencies. Each object implements 'inject' method that can finally
by used to inject mocks in tests.
